### PR TITLE
Development

### DIFF
--- a/include/utilities.h
+++ b/include/utilities.h
@@ -18,10 +18,12 @@ extern double wallclock();
 extern void azzero(double *d, const int n);
 extern double pbc(double x, const double boxby2);
 extern void ekin(mdsys_t *sys);
+#if defined(_MPI)
 extern void mpi_init();
 extern void mpi_finalize();
 extern void mpi_get_rank(mdsys_t *sys);
 extern void mpi_get_size(mdsys_t *sys);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -79,6 +79,7 @@ void ekin(mdsys_t *sys)
     sys->temp = 2.0*sys->ekin/(3.0*sys->natoms-3.0)/kboltz;
 }
 
+#if defined(_MPI)
 void mpi_init(mdsys_t *sys){
     MPI_Init(NULL, NULL);
     sys->syscomm = MPI_COMM_WORLD;
@@ -94,3 +95,4 @@ void mpi_get_rank(mdsys_t *sys){
 void mpi_get_size(mdsys_t *sys){
     MPI_Comm_size(MPI_COMM_WORLD, &sys->npes);
 };
+#endif


### PR DESCRIPTION
Functions in Utilities must be active when _MPI is ON.